### PR TITLE
Refactor registering-proxy.ts to separate concerns and use proper testing patterns

### DIFF
--- a/src/lib-test/MockRegistrar.ts
+++ b/src/lib-test/MockRegistrar.ts
@@ -1,0 +1,21 @@
+import { vi } from "vitest";
+import { Registrar } from "../poc/registering-proxy";
+import type { Registerable } from "../poc/registering-proxy";
+
+export class MockRegistrar<T extends Registerable> extends Registrar<T> {
+  public ensureRegisteredSpy = vi.fn();
+  private mockRegistered = false;
+
+  async ensureRegistered(): Promise<void> {
+    this.ensureRegisteredSpy();
+    if (this.mockRegistered) return;
+
+    await super.ensureRegistered();
+    this.mockRegistered = true;
+  }
+
+  reset() {
+    this.ensureRegisteredSpy.mockClear();
+    this.mockRegistered = false;
+  }
+}

--- a/src/lib-test/fixtures.ts
+++ b/src/lib-test/fixtures.ts
@@ -1,0 +1,8 @@
+import type { Registerable } from "../poc/registering-proxy";
+
+export interface Client extends Registerable {
+  register: () => Promise<void>;
+  operation1: () => Promise<void>;
+  operation2: () => void;
+  operation3: (foo: string) => Promise<number>;
+}

--- a/src/poc/registering-proxy.test.ts
+++ b/src/poc/registering-proxy.test.ts
@@ -2,9 +2,9 @@ import { describe, test, expect, vi } from "vitest";
 import {
   createAutoRegisterProxy,
   createAutoRegisterProxyFor,
-  MockRegistrar,
 } from "./registering-proxy";
-import type { Client } from "./registering-proxy";
+import { MockRegistrar } from "../lib-test/MockRegistrar";
+import type { Client } from "../lib-test/fixtures";
 
 describe("Auto Register Proxy", () => {
   test("should call register before operations using convenience function", async () => {
@@ -40,17 +40,17 @@ describe("Auto Register Proxy", () => {
     const mockRegistrar = new MockRegistrar(client);
     const proxy = createAutoRegisterProxy(mockRegistrar);
 
-    expect(mockRegistrar.ensureRegisteredCallCount).toBe(0);
+    expect(mockRegistrar.ensureRegisteredSpy).toHaveBeenCalledTimes(0);
     expect(mockRegistrar.getRegistrationStatus()).toBe(false);
 
     await proxy.operation1();
 
-    expect(mockRegistrar.ensureRegisteredCallCount).toBe(1);
+    expect(mockRegistrar.ensureRegisteredSpy).toHaveBeenCalledTimes(1);
     expect(mockRegistrar.getRegistrationStatus()).toBe(true);
 
     // Call again to verify ensureRegistered is called again but registration status remains true
     await proxy.operation1();
-    expect(mockRegistrar.ensureRegisteredCallCount).toBe(2);
+    expect(mockRegistrar.ensureRegisteredSpy).toHaveBeenCalledTimes(2);
     expect(mockRegistrar.getRegistrationStatus()).toBe(true);
   });
 

--- a/src/poc/registering-proxy.ts
+++ b/src/poc/registering-proxy.ts
@@ -71,26 +71,3 @@ export function createAutoRegisterProxyFor<T extends Registerable>(
 ): T {
   return createAutoRegisterProxy(new Registrar(client));
 }
-
-// Example interfaces
-export interface Client extends Registerable {
-  register: () => Promise<void>;
-  operation1: () => Promise<void>;
-  operation2: () => void;
-  operation3: (foo: string) => Promise<number>;
-}
-
-// Mock registrar for testing
-export class MockRegistrar<T extends Registerable> extends Registrar<T> {
-  public ensureRegisteredCallCount = 0;
-  public mockRegistered = false;
-
-  async ensureRegistered(): Promise<void> {
-    this.ensureRegisteredCallCount++;
-    if (this.mockRegistered) return;
-
-    // For testing, we can control when registration happens
-    await super.ensureRegistered();
-    this.mockRegistered = true;
-  }
-}


### PR DESCRIPTION
## Summary

- Separated production code from test utilities by moving MockRegistrar and Client interface to new `src/lib-test/` directory
- Replaced manual test tracking with proper vitest mocks using `vi.fn()` and spy functions
- Cleaned up production code to contain only production interfaces and classes
- All existing tests continue to pass with improved testing patterns

Fixes #2

## Test plan

- [x] All existing tests pass
- [x] Build succeeds without TypeScript errors  
- [x] Lint passes
- [x] Production code no longer contains test utilities
- [x] MockRegistrar uses proper vitest mocking instead of manual counters

🤖 Generated with [opencode](https://opencode.ai)