### PR TITLE
Add 'in progress' label step to GitHub issue workflow

### DIFF
--- a/rules/github.md
+++ b/rules/github.md
@@ -4,5 +4,5 @@
 
 <dl>
   <dt>gh: next issue</dt>
-  <dd>find issues labelled "ready for agent", if there's only one issue then make a branch from the latest version of main in the remote, implement the issue and then open a PR. if there is more than one then list the names of the ussues along with the issue number and wait for me to tell you which one to pick up.</dd>
+  <dd>find issues labelled "ready for agent", if there's only one issue then add the "in progress" label to the issue, make a branch from the latest version of main in the remote, implement the issue and then open a PR. if there is more than one then list the names of the ussues along with the issue number and wait for me to tell you which one to pick up.</dd>
 </dl>


### PR DESCRIPTION
## Summary

- Add step to apply "in progress" label when picking up a GitHub issue in the agent workflow

## Test plan

- [x] Verify the GitHub rules documentation is updated correctly
- [x] Confirm the workflow instruction is clear and actionable

🤖 Generated with [opencode](https://opencode.ai)