### PR TITLE
Phase 1: Adapt RpcClient to implement Registerable interface

### DIFF
--- a/src/components/RpcTest.tsx
+++ b/src/components/RpcTest.tsx
@@ -1,30 +1,32 @@
-import { useState } from 'react';
-import { rpcClient } from '../rpc/client';
+import { useState } from "react";
+import { rpcClient } from "../rpc/client";
 
 export function RpcTest() {
-  const [status, setStatus] = useState<string>('Not connected');
+  const [status, setStatus] = useState<string>("Not connected");
   const [isLoading, setIsLoading] = useState<boolean>(false);
 
   const handleTestRpc = async () => {
     setIsLoading(true);
-    setStatus('Connecting...');
-    
+    setStatus("Connecting...");
+
     try {
-      await rpcClient.registerClient();
-      setStatus('Successfully registered client!');
+      await rpcClient.register();
+      setStatus("Successfully registered client!");
     } catch (error) {
-      setStatus(`Error: ${error instanceof Error ? error.message : 'Unknown error'}`);
+      setStatus(
+        `Error: ${error instanceof Error ? error.message : "Unknown error"}`
+      );
     } finally {
       setIsLoading(false);
     }
   };
 
   return (
-    <div style={{ padding: '20px', border: '1px solid #ccc', margin: '20px' }}>
+    <div style={{ padding: "20px", border: "1px solid #ccc", margin: "20px" }}>
       <h3>RPC System Test</h3>
       <p>Status: {status}</p>
       <button onClick={handleTestRpc} disabled={isLoading}>
-        {isLoading ? 'Testing...' : 'Test RPC Communication'}
+        {isLoading ? "Testing..." : "Test RPC Communication"}
       </button>
     </div>
   );

--- a/src/rpc/RpcClient.test.ts
+++ b/src/rpc/RpcClient.test.ts
@@ -9,27 +9,21 @@ vi.mock("../utils/uuid", () => ({
   generateUUID: vi.fn(() => TEST_CLIENT_ID),
 }));
 
-// Define proper mock type for Remote<RpcWorker>
-interface MockRpcWorker {
-  registerClient: (clientId: string) => Promise<void>;
-  ping: () => Promise<string>;
-  getStatus: () => Promise<{ connected: boolean }>;
-}
-
 describe("RpcClient", () => {
-  let mockRemote: MockRpcWorker;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let mockRemote: any;
   let rpcClient: RpcClient;
 
   beforeEach(() => {
-    // Create a mock remote object with proper method signatures
+    // Create a mock remote object
     mockRemote = {
       registerClient: vi.fn().mockResolvedValue(undefined),
       ping: vi.fn().mockResolvedValue("pong from worker"),
       getStatus: vi.fn().mockResolvedValue({ connected: true }),
     };
 
-    // Type assertion is necessary here due to Comlink's complex Remote type
-    rpcClient = new RpcClient(mockRemote as never);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    rpcClient = new RpcClient(mockRemote as any);
   });
 
   describe("Registerable interface implementation", () => {
@@ -122,8 +116,10 @@ describe("RpcClient", () => {
 
   describe("constructor", () => {
     it("should generate unique client ID", () => {
-      const client1 = new RpcClient(mockRemote as never);
-      const client2 = new RpcClient(mockRemote as never);
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const client1 = new RpcClient(mockRemote as any);
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const client2 = new RpcClient(mockRemote as any);
 
       // Both should have the same ID since we're mocking generateUUID
       expect(client1).toBeDefined();
@@ -131,7 +127,8 @@ describe("RpcClient", () => {
     });
 
     it("should store remote reference", () => {
-      const client = new RpcClient(mockRemote as never);
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const client = new RpcClient(mockRemote as any);
       expect(client).toBeDefined();
     });
   });
@@ -139,7 +136,8 @@ describe("RpcClient", () => {
   describe("type compatibility", () => {
     it("should be compatible with RpcClient interface from types", () => {
       // This test ensures the class implements the interface correctly
-      const client = new RpcClient(mockRemote as never);
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const client = new RpcClient(mockRemote as any);
 
       expect(typeof client.registerClient).toBe("function");
       expect(typeof client.ping).toBe("function");

--- a/src/rpc/RpcClient.test.ts
+++ b/src/rpc/RpcClient.test.ts
@@ -1,0 +1,147 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { RpcClient } from "./RpcClient";
+import type { Registerable } from "./types";
+
+// Mock the UUID generator
+vi.mock("../utils/uuid", () => ({
+  generateUUID: vi.fn(() => "test-client-id-123"),
+}));
+
+describe("RpcClient", () => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let mockRemote: any;
+  let rpcClient: RpcClient;
+
+  beforeEach(() => {
+    // Create a mock remote object
+    mockRemote = {
+      registerClient: vi.fn().mockResolvedValue(undefined),
+      ping: vi.fn().mockResolvedValue("pong from worker"),
+      getStatus: vi.fn().mockResolvedValue({ connected: true }),
+    };
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    rpcClient = new RpcClient(mockRemote as any);
+
+    rpcClient = new RpcClient(mockRemote);
+  });
+
+  describe("Registerable interface implementation", () => {
+    it("should implement Registerable interface", () => {
+      // Type assertion to ensure RpcClient implements Registerable
+      const registerable: Registerable = rpcClient;
+      expect(registerable).toBeDefined();
+      expect(typeof registerable.register).toBe("function");
+    });
+
+    it("should have register method that returns a Promise", () => {
+      const result = rpcClient.register();
+      expect(result).toBeInstanceOf(Promise);
+    });
+  });
+
+  describe("register() method", () => {
+    it("should call remote.registerClient with client ID", async () => {
+      await rpcClient.register();
+
+      expect(mockRemote.registerClient).toHaveBeenCalledTimes(1);
+      expect(mockRemote.registerClient).toHaveBeenCalledWith(
+        "test-client-id-123"
+      );
+    });
+
+    it("should handle registration errors", async () => {
+      const error = new Error("Registration failed");
+      mockRemote.registerClient = vi.fn().mockRejectedValue(error);
+
+      await expect(rpcClient.register()).rejects.toThrow("Registration failed");
+    });
+  });
+
+  describe("registerClient() method - backward compatibility", () => {
+    it("should exist for backward compatibility", () => {
+      expect(typeof rpcClient.registerClient).toBe("function");
+    });
+
+    it("should delegate to register() method", async () => {
+      const registerSpy = vi.spyOn(rpcClient, "register");
+
+      await rpcClient.registerClient();
+
+      expect(registerSpy).toHaveBeenCalledTimes(1);
+      expect(mockRemote.registerClient).toHaveBeenCalledWith(
+        "test-client-id-123"
+      );
+    });
+
+    it("should return the same result as register()", async () => {
+      const registerResult = rpcClient.register();
+      const registerClientResult = rpcClient.registerClient();
+
+      // Both should return promises that resolve to undefined
+      await expect(registerResult).resolves.toBeUndefined();
+      await expect(registerClientResult).resolves.toBeUndefined();
+    });
+  });
+
+  describe("ping() method", () => {
+    it("should return pong message with client ID", async () => {
+      const result = await rpcClient.ping();
+
+      expect(result).toBe("pong from client test-client-id-123");
+    });
+
+    it("should return a string", async () => {
+      const result = await rpcClient.ping();
+
+      expect(typeof result).toBe("string");
+    });
+  });
+
+  describe("getStatus() method", () => {
+    it("should return status object with client ID and connected state", async () => {
+      const result = await rpcClient.getStatus();
+
+      expect(result).toEqual({
+        clientId: "test-client-id-123",
+        connected: true,
+      });
+    });
+
+    it("should return object with correct structure", async () => {
+      const result = await rpcClient.getStatus();
+
+      expect(result).toHaveProperty("clientId");
+      expect(result).toHaveProperty("connected");
+      expect(typeof result.clientId).toBe("string");
+      expect(typeof result.connected).toBe("boolean");
+    });
+  });
+
+  describe("constructor", () => {
+    it("should generate unique client ID", () => {
+      const client1 = new RpcClient(mockRemote);
+      const client2 = new RpcClient(mockRemote);
+
+      // Both should have the same ID since we're mocking generateUUID
+      expect(client1).toBeDefined();
+      expect(client2).toBeDefined();
+    });
+
+    it("should store remote reference", () => {
+      const client = new RpcClient(mockRemote);
+      expect(client).toBeDefined();
+    });
+  });
+
+  describe("type compatibility", () => {
+    it("should be compatible with RpcClient interface from types", () => {
+      // This test ensures the class implements the interface correctly
+      const client = new RpcClient(mockRemote);
+
+      expect(typeof client.registerClient).toBe("function");
+      expect(typeof client.ping).toBe("function");
+      expect(typeof client.getStatus).toBe("function");
+    });
+  });
+});

--- a/src/rpc/RpcClient.ts
+++ b/src/rpc/RpcClient.ts
@@ -1,8 +1,8 @@
-import type { Remote } from 'comlink';
-import type { RpcWorker } from './types';
-import { generateUUID } from '../utils/uuid';
+import type { Remote } from "comlink";
+import type { RpcWorker, Registerable } from "./types";
+import { generateUUID } from "../utils/uuid";
 
-export class RpcClient {
+export class RpcClient implements Registerable {
   private clientId: string;
   private remote: Remote<RpcWorker>;
 
@@ -11,7 +11,22 @@ export class RpcClient {
     this.clientId = generateUUID();
   }
 
-  async registerClient(): Promise<void> {
+  async register(): Promise<void> {
     await this.remote.registerClient(this.clientId);
+  }
+
+  async registerClient(): Promise<void> {
+    return this.register();
+  }
+
+  async ping(): Promise<string> {
+    return `pong from client ${this.clientId}`;
+  }
+
+  async getStatus(): Promise<{ clientId: string; connected: boolean }> {
+    return {
+      clientId: this.clientId,
+      connected: true,
+    };
   }
 }

--- a/src/rpc/types.ts
+++ b/src/rpc/types.ts
@@ -1,7 +1,13 @@
-import type { WithIndexedOperations } from '../lib/rpc-types';
+import type { WithIndexedOperations } from "../lib/rpc-types";
+
+export interface Registerable {
+  register: () => Promise<void>;
+}
 
 export interface RpcClient {
   registerClient: () => Promise<void>;
+  ping: () => Promise<string>;
+  getStatus: () => Promise<{ clientId: string; connected: boolean }>;
 }
 
 export type RpcWorker = WithIndexedOperations<RpcClient>;


### PR DESCRIPTION
## Summary

- Implements the `Registerable` interface for `RpcClient` class to prepare for auto-registration proxy integration
- Adds new `register()` method while maintaining backward compatibility with existing `registerClient()` method
- Includes placeholder RPC methods (`ping()`, `getStatus()`) that will benefit from auto-registration

## Changes Made

- **Added `Registerable` interface** to `src/rpc/types.ts` with `register()` method signature
- **Updated `RpcClient` class** to implement `Registerable` interface
- **Renamed primary method** from `registerClient()` to `register()` for interface consistency
- **Maintained backward compatibility** by keeping `registerClient()` method that delegates to `register()`
- **Added placeholder RPC methods**: `ping()` and `getStatus()` with appropriate return types
- **Updated component usage** in `RpcTest.tsx` to use new `register()` method

## Testing

- [x] TypeScript compilation passes without errors
- [x] ESLint passes without warnings
- [x] Existing client instantiation continues to work
- [x] No breaking changes to current usage
- [x] Build process completes successfully

## Acceptance Criteria

- [x] `RpcClient` implements `Registerable` interface
- [x] `register()` method maintains existing functionality  
- [x] TypeScript compilation passes without errors
- [x] Existing client instantiation continues to work
- [x] No breaking changes to current usage

Closes #5

🤖 Generated with [opencode](https://opencode.ai)